### PR TITLE
feat(compiler): did-you-mean suggestions for unknown components + props

### DIFF
--- a/ruitl_compiler/Cargo.toml
+++ b/ruitl_compiler/Cargo.toml
@@ -17,3 +17,4 @@ syn = { version = "2.0", features = ["full"] }
 thiserror = "1.0"
 walkdir = "2.3"
 md5 = "0.7"
+strsim = "0.11"

--- a/ruitl_compiler/src/codegen.rs
+++ b/ruitl_compiler/src/codegen.rs
@@ -118,6 +118,12 @@ impl CodeGenerator {
 
     /// Generate complete Rust code for the entire file
     pub fn generate(&mut self) -> Result<TokenStream> {
+        // Check templates for undefined `@Component` references, unknown
+        // props at call sites, and reserved-name collisions before emitting
+        // any tokens. Failing fast here produces cleaner error messages than
+        // letting `syn`/`rustc` complain about the generated output.
+        self.validate_references()?;
+
         // Generate imports
         self.generate_imports()?;
 
@@ -966,6 +972,163 @@ impl CodeGenerator {
             .find(|t| t.name == name)
             .map(|t| Self::body_has_children_slot(&t.body))
             .unwrap_or(false)
+    }
+
+    /// Walk every template body once to surface broken `@Component(...)`
+    /// call sites before codegen. For each invocation we check:
+    ///   * component name is declared in this file or imported
+    ///   * every prop name matches a field on the callee's Props struct
+    ///     (only verifiable for same-file callees — out-of-file types are
+    ///     opaque here and left to `rustc`)
+    /// Suggestions are appended to the error message via `suggest::help_line`
+    /// so both CLI consumers and the LSP pick them up without structural
+    /// changes to `CompileError`.
+    fn validate_references(&self) -> Result<()> {
+        let known_components: Vec<&str> = self
+            .file
+            .components
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        let imported_items: Vec<&str> = self
+            .file
+            .imports
+            .iter()
+            .flat_map(|imp| imp.items.iter().map(String::as_str))
+            .collect();
+
+        for tpl in &self.file.templates {
+            self.walk_validate(&tpl.body, &known_components, &imported_items, &tpl.name)?;
+        }
+        Ok(())
+    }
+
+    fn walk_validate(
+        &self,
+        ast: &TemplateAst,
+        known_components: &[&str],
+        imported_items: &[&str],
+        current_template: &str,
+    ) -> Result<()> {
+        match ast {
+            TemplateAst::Component {
+                name,
+                props,
+                children,
+            } => {
+                // Cross-file `@Component` invocations are legal: callees are
+                // resolved through the generated `mod.rs` module at Rust
+                // compile time, not at ruitl-compile time. So *don't* error
+                // on "unknown component" blindly — it would reject legit
+                // multi-file projects. Only error when the name is close
+                // enough to an in-file declaration to look like a typo.
+                let is_known = known_components.iter().any(|k| k == name)
+                    || imported_items.iter().any(|k| k == name);
+                if !is_known {
+                    let mut candidates: Vec<&str> = known_components.to_vec();
+                    candidates.extend_from_slice(imported_items);
+                    if let Some(suggestion) = crate::suggest::suggest(name, &candidates) {
+                        return Err(CompileError::codegen(format!(
+                            "Unknown component `{}` invoked via `@{}` in template `{}`.{}",
+                            name,
+                            name,
+                            current_template,
+                            crate::suggest::help_line(Some(suggestion.as_str()))
+                        )));
+                    }
+                    // No close match → assume it's a cross-file callee.
+                    // Fall through; skip prop validation (can't see the
+                    // callee's props from here).
+                    if let Some(body) = children {
+                        self.walk_validate(
+                            body,
+                            known_components,
+                            imported_items,
+                            current_template,
+                        )?;
+                    }
+                    return Ok(());
+                }
+
+                // Same-file callees: check prop names against the callee's
+                // declared prop list. Out-of-file (imported) callees stay
+                // opaque here; `rustc` will catch mistypes on the struct
+                // literal downstream.
+                if let Some(callee) = self.file.components.iter().find(|c| c.name == *name) {
+                    let declared: Vec<&str> =
+                        callee.props.iter().map(|p| p.name.as_str()).collect();
+                    // `children` is auto-injected when the slot is used and
+                    // is always a legal prop name at call sites.
+                    let legal_extra = ["children"];
+                    for pv in props {
+                        let is_declared =
+                            declared.contains(&pv.name.as_str()) || legal_extra.contains(&pv.name.as_str());
+                        if !is_declared {
+                            let suggestion = crate::suggest::suggest(&pv.name, &declared);
+                            return Err(CompileError::codegen(format!(
+                                "No prop `{}` on `{}Props` (called from template `{}`).{}",
+                                pv.name,
+                                name,
+                                current_template,
+                                crate::suggest::help_line(suggestion.as_deref())
+                            )));
+                        }
+                    }
+                }
+
+                if let Some(body) = children {
+                    self.walk_validate(body, known_components, imported_items, current_template)?;
+                }
+                Ok(())
+            }
+            TemplateAst::Element { children, .. } => {
+                for c in children {
+                    self.walk_validate(c, known_components, imported_items, current_template)?;
+                }
+                Ok(())
+            }
+            TemplateAst::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                self.walk_validate(
+                    then_branch,
+                    known_components,
+                    imported_items,
+                    current_template,
+                )?;
+                if let Some(e) = else_branch {
+                    self.walk_validate(e, known_components, imported_items, current_template)?;
+                }
+                Ok(())
+            }
+            TemplateAst::For { body, .. } => {
+                self.walk_validate(body, known_components, imported_items, current_template)
+            }
+            TemplateAst::Match { arms, .. } => {
+                for arm in arms {
+                    self.walk_validate(
+                        &arm.body,
+                        known_components,
+                        imported_items,
+                        current_template,
+                    )?;
+                }
+                Ok(())
+            }
+            TemplateAst::Fragment(nodes) => {
+                for n in nodes {
+                    self.walk_validate(n, known_components, imported_items, current_template)?;
+                }
+                Ok(())
+            }
+            TemplateAst::Text(_)
+            | TemplateAst::Expression(_)
+            | TemplateAst::RawExpression(_)
+            | TemplateAst::Raw(_)
+            | TemplateAst::Children => Ok(()),
+        }
     }
 
     /// Recursively checks whether `ast` contains a `TemplateAst::Children`

--- a/ruitl_compiler/src/lib.rs
+++ b/ruitl_compiler/src/lib.rs
@@ -10,6 +10,7 @@ pub mod codegen;
 pub mod error;
 pub mod format;
 pub mod parser;
+pub mod suggest;
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/ruitl_compiler/src/suggest.rs
+++ b/ruitl_compiler/src/suggest.rs
@@ -1,0 +1,86 @@
+//! Fuzzy-match helpers for "did you mean" diagnostics.
+//!
+//! Only used by the codegen validation pass and by consumers of the public
+//! `Result` type; self-contained to keep dependency surface narrow.
+
+/// Pick the closest string in `haystack` to `needle` by Levenshtein distance,
+/// if one is within `max_distance`. Ties resolve to the first candidate in
+/// `haystack` order (stable, so callers can influence priority by sorting).
+pub fn closest(needle: &str, haystack: &[&str], max_distance: usize) -> Option<String> {
+    haystack
+        .iter()
+        .map(|cand| (*cand, strsim::levenshtein(needle, cand)))
+        .filter(|(_, d)| *d <= max_distance)
+        .min_by_key(|(_, d)| *d)
+        .map(|(cand, _)| cand.to_string())
+}
+
+/// Distance threshold tuned to the length of the identifier: short idents
+/// (≤4 chars) accept at most distance 2; longer idents scale at ~1/3 length
+/// but cap at 3 to avoid suggesting wildly different names on long idents.
+pub fn threshold_for(ident: &str) -> usize {
+    let len = ident.chars().count();
+    if len <= 4 {
+        2
+    } else {
+        (len / 3).min(3).max(1)
+    }
+}
+
+/// Convenience: combine `threshold_for` + `closest` into a single call.
+pub fn suggest(needle: &str, haystack: &[&str]) -> Option<String> {
+    closest(needle, haystack, threshold_for(needle))
+}
+
+/// Render a suggestion as a help footer line, or an empty string if
+/// `suggestion` is `None`. Keeps error-message construction terse.
+pub fn help_line(suggestion: Option<&str>) -> String {
+    match suggestion {
+        Some(s) => format!("\n  help: did you mean `{}`?", s),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_close_match() {
+        let haystack = ["text", "target", "size"];
+        assert_eq!(suggest("texx", &haystack).as_deref(), Some("text"));
+    }
+
+    #[test]
+    fn rejects_wildly_different() {
+        let haystack = ["text", "target", "size"];
+        assert_eq!(suggest("foo", &haystack), None);
+    }
+
+    #[test]
+    fn stable_tie_break_returns_first_by_order() {
+        // "xxxx" is distance 4 from both — above threshold (2 for len 4) —
+        // so no suggestion. Use a case that ties within threshold instead.
+        // "tex" ↔ "text"=1 vs "size"=4: text wins.
+        let haystack = ["text", "size"];
+        assert_eq!(suggest("tex", &haystack).as_deref(), Some("text"));
+    }
+
+    #[test]
+    fn threshold_scales_with_len() {
+        assert_eq!(threshold_for("ab"), 2);
+        assert_eq!(threshold_for("abcd"), 2);
+        assert_eq!(threshold_for("abcdef"), 2); // 6/3 = 2
+        assert_eq!(threshold_for("abcdefghi"), 3); // 9/3 = 3
+        assert_eq!(threshold_for("abcdefghijkl"), 3); // cap at 3
+    }
+
+    #[test]
+    fn help_line_formats_suggestion() {
+        assert_eq!(
+            help_line(Some("Button")),
+            "\n  help: did you mean `Button`?"
+        );
+        assert_eq!(help_line(None), "");
+    }
+}

--- a/tests/error_suggestions.rs
+++ b/tests/error_suggestions.rs
@@ -1,0 +1,39 @@
+//! End-to-end tests for "did you mean" codegen diagnostics.
+//!
+//! Each fixture in `tests/fixtures/errors/` is intentionally broken: we
+//! assert that codegen refuses it and that the error message carries a
+//! matching suggestion line.
+
+use ruitl_compiler::{generate, parse_str};
+
+#[test]
+fn unknown_component_suggests_declared_name() {
+    let src = include_str!("fixtures/errors/typo_component.ruitl");
+    let ast = parse_str(src).expect("fixture must parse — only codegen is broken");
+    let err = generate(ast).expect_err("codegen must reject @Buttom");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Unknown component `Buttom`"),
+        "message should name the unknown component, got:\n{msg}"
+    );
+    assert!(
+        msg.contains("did you mean `Button`?"),
+        "message should suggest `Button`, got:\n{msg}"
+    );
+}
+
+#[test]
+fn unknown_prop_suggests_declared_prop() {
+    let src = include_str!("fixtures/errors/typo_prop.ruitl");
+    let ast = parse_str(src).expect("fixture must parse");
+    let err = generate(ast).expect_err("codegen must reject @Button(texx: ...)");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("No prop `texx` on `ButtonProps`"),
+        "message should name the unknown prop, got:\n{msg}"
+    );
+    assert!(
+        msg.contains("did you mean `text`?"),
+        "message should suggest `text`, got:\n{msg}"
+    );
+}

--- a/tests/fixtures/errors/typo_component.ruitl
+++ b/tests/fixtures/errors/typo_component.ruitl
@@ -1,0 +1,23 @@
+// Fixture: invokes a mistyped component name (`@Buttom`) where only
+// `@Button` is declared. Codegen validation must reject it with a
+// "did you mean `Button`?" suggestion.
+
+component Button {
+    props {
+        text: String,
+    }
+}
+
+ruitl Button(text: String) {
+    <button>{text}</button>
+}
+
+component Page {
+    props {}
+}
+
+ruitl Page() {
+    <section>
+        @Buttom(text: "Click".to_string())
+    </section>
+}

--- a/tests/fixtures/errors/typo_prop.ruitl
+++ b/tests/fixtures/errors/typo_prop.ruitl
@@ -1,0 +1,22 @@
+// Fixture: invokes `@Button(texx: ...)` where Button declares `text`.
+// Codegen validation must reject the unknown prop with a suggestion.
+
+component Button {
+    props {
+        text: String,
+    }
+}
+
+ruitl Button(text: String) {
+    <button>{text}</button>
+}
+
+component Page {
+    props {}
+}
+
+ruitl Page() {
+    <section>
+        @Button(texx: "Click".to_string())
+    </section>
+}


### PR DESCRIPTION
## Summary

Adds structured \"did you mean?\" diagnostics to codegen:

- Pre-codegen validation walks every \`@Component\` invocation.
- Unknown names close to a declared component (Levenshtein within a length-scaled threshold) produce an error with a \"help: did you mean \`X\`?\" footer. Names with no close match pass through silently — cross-file \`@\`-refs are legal and resolved by the generated \`mod.rs\` at Rust-compile time.
- For same-file callees, each call-site prop name is checked against the declared prop list and suggests the closest declared name on misses.
- New \`ruitl_compiler::suggest\` module owns the fuzzy matcher (wraps \`strsim::levenshtein\`), threshold heuristic, and help-line rendering.
- The LSP (\`ruitl_lsp\`) surfaces the footer as-is through \`textDocument/publishDiagnostics\` — no structural changes needed there.

## Example

\`\`\`
Code generation error: Unknown component \`Buttom\` invoked via \`@Buttom\` in template \`Page\`.
  help: did you mean \`Button\`?
\`\`\`

## Scope

- **new**: \`ruitl_compiler/src/suggest.rs\` (Levenshtein + threshold + help-line helper)
- **codegen**: \`CodeGenerator::validate_references\` pass before token emission
- **deps**: adds \`strsim = \"0.11\"\` to \`ruitl_compiler\` (4 kB, no deps)
- **tests**: \`tests/fixtures/errors/typo_component.ruitl\`, \`tests/fixtures/errors/typo_prop.ruitl\`, \`tests/error_suggestions.rs\`

## Stacked on

Targets \`feature/v0.3-children-prop\` (#7). Merge that first, then re-target this PR at \`main\` or rebase.

## Test plan

- [ ] \`cargo test -p ruitl_compiler suggest\`
- [ ] \`cargo test --test error_suggestions\`
- [ ] CLI smoke: \`cargo run --bin ruitl -- compile --src-dir <dir-with-typo>\` surfaces the help line

🤖 Generated with [Claude Code](https://claude.com/claude-code)