### PR TITLE
perf: rayon-parallel compile_dir + buffer-reuse render API + benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,10 @@ harness = false
 name = "render"
 harness = false
 
+[[bench]]
+name = "compile_dir"
+harness = false
+
 [features]
 default = ["server", "static", "dev"]
 server = ["dep:hyper", "dep:hyper-tls", "tokio/rt-multi-thread"]

--- a/benches/compile_dir.rs
+++ b/benches/compile_dir.rs
@@ -1,0 +1,63 @@
+//! `compile_dir_sibling` throughput benchmark.
+//!
+//! Generates N synthetic `.ruitl` files in a tempdir and measures the full
+//! parse + codegen + write pipeline. Useful for tracking parallel speedups
+//! (compare with/without the `parallel` feature on the `ruitl_compiler`
+//! dependency).
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use ruitl_compiler::compile_dir_sibling;
+use std::fs;
+use tempfile::TempDir;
+
+fn synth_template(idx: usize) -> String {
+    format!(
+        r#"// Synthetic fixture #{idx}.
+component Card{idx} {{
+    props {{
+        title: String,
+        body: String,
+    }}
+}}
+
+ruitl Card{idx}(title: String, body: String) {{
+    <article class="card-{idx}">
+        <h1>{{title}}</h1>
+        <p>{{body}}</p>
+    </article>
+}}
+"#
+    )
+}
+
+fn populate(dir: &std::path::Path, count: usize) {
+    for i in 0..count {
+        fs::write(dir.join(format!("Card{i}.ruitl")), synth_template(i)).unwrap();
+    }
+}
+
+fn bench_compile_dir(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compile_dir_sibling");
+    for size in &[10usize, 100, 500] {
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &count| {
+            b.iter_custom(|iters| {
+                let mut total = std::time::Duration::ZERO;
+                for _ in 0..iters {
+                    // Fresh tempdir per iteration so the hash-skip cache is
+                    // cold — we want to measure the full parse+codegen
+                    // pipeline, not the no-op fast path.
+                    let dir = TempDir::new().unwrap();
+                    populate(dir.path(), count);
+                    let start = std::time::Instant::now();
+                    compile_dir_sibling(dir.path()).unwrap();
+                    total += start.elapsed();
+                }
+                total
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_compile_dir);
+criterion_main!(benches);

--- a/benches/render.rs
+++ b/benches/render.rs
@@ -29,6 +29,22 @@ fn bench_render(c: &mut Criterion) {
     let mut group = c.benchmark_group("Html::render");
     group.bench_function("small_10", |b| b.iter(|| small.render()));
     group.bench_function("big_1000", |b| b.iter(|| big.render()));
+    // Model the hot request-handler path: one long-lived buffer, cleared
+    // between iterations. Captures the win from `render_into`'s amortised
+    // capacity.
+    group.bench_function("render_into_reused_big_1000", |b| {
+        let mut buf = String::with_capacity(big.len_hint());
+        b.iter(|| {
+            buf.clear();
+            big.render_into(&mut buf).unwrap();
+        })
+    });
+    // Size-hint path: allocate with `len_hint()` up front, avoiding reallocs
+    // during the render. Compare against the default `render()` to decide
+    // whether to wire `len_hint` into the default path.
+    group.bench_function("render_with_capacity_big_1000", |b| {
+        b.iter(|| big.render_with_capacity(big.len_hint()))
+    });
     group.finish();
 }
 

--- a/ruitl_compiler/Cargo.toml
+++ b/ruitl_compiler/Cargo.toml
@@ -18,3 +18,12 @@ thiserror = "1.0"
 walkdir = "2.3"
 md5 = "0.7"
 strsim = "0.11"
+rayon = { version = "1.10", optional = true }
+
+[features]
+default = ["parallel"]
+# `parallel` switches `compile_dir_sibling` to a rayon-backed par_iter. Each
+# file writes to a distinct output path so there is no contention; disabling
+# this feature keeps compile order strictly sequential (useful when profiling
+# the single-thread path or on hosts that don't love rayon).
+parallel = ["dep:rayon"]

--- a/ruitl_compiler/src/lib.rs
+++ b/ruitl_compiler/src/lib.rs
@@ -110,21 +110,62 @@ fn extract_hash(content: &str) -> Option<&str> {
 /// and re-exports each compiled module, so consumers can `mod templates;`.
 /// Returns the list of written output paths.
 pub fn compile_dir_sibling(dir: &Path) -> Result<Vec<PathBuf>> {
-    let mut outputs = Vec::new();
     if !dir.exists() {
-        return Ok(outputs);
+        return Ok(Vec::new());
     }
-    let mut module_stems: Vec<String> = Vec::new();
-    for entry in walkdir::WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
-        let path = entry.path();
-        if path.is_file() && path.extension().map(|e| e == "ruitl").unwrap_or(false) {
-            let out = compile_file_sibling(path)?;
-            if let Some(stem) = out.file_stem().and_then(|s| s.to_str()) {
-                module_stems.push(stem.to_string());
+    // Collect `.ruitl` paths first so the expensive parse+codegen step can
+    // fan out across threads. `walkdir` is single-threaded by construction.
+    let inputs: Vec<PathBuf> = walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path().is_file()
+                && e.path().extension().map(|x| x == "ruitl").unwrap_or(false)
+        })
+        .map(|e| e.path().to_path_buf())
+        .collect();
+
+    // Fan-out: each file writes to a distinct `<stem>_ruitl.rs` output, so
+    // there is no write contention. Errors from one file don't short-circuit
+    // the others — collect them all, then report the first so CI logs are
+    // deterministic. With `parallel` off (rayon absent) this reduces to a
+    // plain `iter()`.
+    let results: Vec<Result<PathBuf>> = {
+        #[cfg(feature = "parallel")]
+        {
+            use rayon::prelude::*;
+            inputs
+                .par_iter()
+                .map(|p| compile_file_sibling(p))
+                .collect()
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            inputs.iter().map(|p| compile_file_sibling(p)).collect()
+        }
+    };
+
+    let mut outputs = Vec::with_capacity(results.len());
+    let mut first_err: Option<CompileError> = None;
+    for r in results {
+        match r {
+            Ok(p) => outputs.push(p),
+            Err(e) => {
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
             }
-            outputs.push(out);
         }
     }
+    if let Some(e) = first_err {
+        return Err(e);
+    }
+
+    let mut module_stems: Vec<String> = outputs
+        .iter()
+        .filter_map(|o| o.file_stem().and_then(|s| s.to_str()).map(String::from))
+        .collect();
+    module_stems.sort();
     if !module_stems.is_empty() {
         write_sibling_mod_file(dir, &module_stems)?;
     }

--- a/src/html.rs
+++ b/src/html.rs
@@ -268,6 +268,67 @@ impl Html {
         maybe_minify(output)
     }
 
+    /// Render into a caller-supplied buffer so hot loops (hyper handlers,
+    /// SSG crawlers) can reuse a single allocation across many renders.
+    /// The buffer is **appended to** — callers who want a fresh payload
+    /// should `buf.clear()` beforehand. Minification runs after the write
+    /// when the `minify` feature is on, identical to `Html::render`.
+    pub fn render_into(&self, buf: &mut String) -> Result<()> {
+        let pre_len = buf.len();
+        self.render_to(buf)?;
+        #[cfg(feature = "minify")]
+        {
+            let written = buf.split_off(pre_len);
+            buf.push_str(&maybe_minify(written));
+        }
+        #[cfg(not(feature = "minify"))]
+        {
+            let _ = pre_len;
+        }
+        Ok(())
+    }
+
+    /// Allocate with a given capacity up-front, then render. Useful when the
+    /// caller has a tighter size estimate than `Html::len_hint` can produce
+    /// — for instance, a cached prior-render length.
+    pub fn render_with_capacity(&self, capacity: usize) -> String {
+        let mut s = String::with_capacity(capacity);
+        let _ = self.render_to(&mut s);
+        maybe_minify(s)
+    }
+
+    /// Cheap lower-bound estimate of the rendered byte length, used to
+    /// pre-size `String` buffers. Walks the tree once and sums a rough
+    /// approximation of tag + attribute + child sizes. Underestimates mean
+    /// one extra realloc during rendering; overestimates waste a bit of
+    /// memory. Both are fine — this is a heuristic, not a contract.
+    pub fn len_hint(&self) -> usize {
+        match self {
+            Html::Text(s) | Html::Raw(s) => s.len(),
+            Html::Element(e) => {
+                let attrs: usize = e
+                    .attributes
+                    .iter()
+                    .map(|(k, v)| {
+                        k.len()
+                            + match v {
+                                HtmlAttribute::Value(s) => s.len() + 4, // `="…" `
+                                HtmlAttribute::Boolean => 1,
+                                HtmlAttribute::List(items) => {
+                                    items.iter().map(|s| s.len() + 1).sum::<usize>() + 3
+                                }
+                            }
+                    })
+                    .sum();
+                let children: usize = e.children.iter().map(|c| c.len_hint()).sum();
+                // Tag open + close = `<tag></tag>` ≈ 5 + 2*tag.len().
+                e.tag.len() * 2 + 5 + attrs + children
+            }
+            Html::Fragment(children) => children.iter().map(|c| c.len_hint()).sum(),
+            Html::Empty => 0,
+        }
+    }
+
     /// Render the HTML to a writer
     pub fn render_to<W: Write>(&self, writer: &mut W) -> Result<()> {
         match self {
@@ -631,6 +692,35 @@ mod tests {
         let element = div().class("test").text("Hello, world!");
         let html = element.render();
         assert_eq!(html, r#"<div class="test">Hello, world!</div>"#);
+    }
+
+    #[test]
+    fn test_render_into_reuses_buffer() {
+        let elem = Html::Element(div().text("one"));
+        let mut buf = String::from("prefix:");
+        elem.render_into(&mut buf).unwrap();
+        assert_eq!(buf, "prefix:<div>one</div>");
+
+        // Same buffer, cleared, second render
+        buf.clear();
+        let elem2 = Html::Element(div().text("two"));
+        elem2.render_into(&mut buf).unwrap();
+        assert_eq!(buf, "<div>two</div>");
+    }
+
+    #[test]
+    fn test_render_with_capacity_matches_render() {
+        let elem = Html::Element(div().class("x").child(Html::text("hi")));
+        let a = elem.render();
+        let b = elem.render_with_capacity(elem.len_hint());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_len_hint_non_zero_for_non_empty() {
+        let elem = Html::Element(div().child(Html::text("hello")));
+        assert!(elem.len_hint() > 0);
+        assert_eq!(Html::Empty.len_hint(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three non-breaking performance additions:

1. **Parallel compile**: \`compile_dir_sibling\` now collects \`.ruitl\` paths first, then fans out over rayon's \`par_iter\` when the new \`parallel\` feature is on (default). Each file writes to a distinct output, so there's no contention. Errors are collected across the whole run and the first reported deterministically for stable CI logs.
2. **Buffer-reuse render API** (\`src/html.rs\`): three non-breaking methods so hot loops can reuse allocations:
   - \`Html::render_into(&mut String)\` — append-only; caller owns the buffer.
   - \`Html::render_with_capacity(usize)\` — one upfront allocation.
   - \`Html::len_hint() -> usize\` — cheap tree-walk size estimate.
3. **Criterion benches**:
   - new \`benches/compile_dir.rs\` axis over 10/100/500 synthetic fixtures; tracks parallel speedups across releases.
   - \`benches/render.rs\` grows \`render_into_reused\` + \`render_with_capacity\` cases for A/B with \`render\`.

\`Html::render\` keeps identical behaviour — no semantic change for existing callers.

## Scope

- **new feature flag**: \`parallel\` in \`ruitl_compiler\` (default on). Disable with \`--no-default-features\` to profile single-threaded compile.
- **deps**: \`rayon = \"1.10\"\` (optional, gated).
- Cargo workspace adds a \`[[bench]] name = \"compile_dir\"\` entry.

## Stacked on

Targets \`feature/v0.3-error-suggestions\` (stack 3 of 8).

## Test plan

- [ ] \`cargo test\` — unit tests for \`render_into\`, \`render_with_capacity\`, \`len_hint\`
- [ ] \`cargo test --no-default-features\` for \`ruitl_compiler\` — verifies the serial fallback still compiles
- [ ] \`cargo bench --bench render\` and \`cargo bench --bench compile_dir\` (baseline with \`--save-baseline pre\` on \`main\`, then compare)

🤖 Generated with [Claude Code](https://claude.com/claude-code)