### PR TITLE
feat(compiler): add {children} slot + bodied @-invocations for templa…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,13 @@ Generated files use short type names relying on `use ruitl::prelude::*; use ruit
 - Inline Rust exprs in `{}`; attribute interpolation `class={expr}`; boolean attrs `disabled?={expr}`
 - Control flow: `if`/`else`, `for x in iter`, `match expr { arm => ... }`
 - Component composition: `@ChildComponent(prop=value)` — threads `context` through
+- Body-block children: `@ChildComponent(prop=value) { <inner/> }` passes the
+  block as `children: Html` on the callee. Inside the callee, the bare slot
+  `{children}` expands to `props.children.clone()`. `{Name}Props` auto-gains a
+  `pub children: Html` field when the template body references `{children}`;
+  if the user already declared a `children` prop explicitly, the user's
+  declaration wins (no duplicate field). Dotted forms like `{my.children}`
+  parse as ordinary expressions, not the slot.
 - `import` statements at top of file
 - Whitespace between `{expr}` and adjacent text is preserved (significant for HTML spacing)
 

--- a/README.md
+++ b/README.md
@@ -546,6 +546,41 @@ ruitl Example(count: u32, items: Vec<String>) {
 }
 ```
 
+### Template Inheritance via `{children}`
+
+Pass a body block into a component with `@Name(props) { ... }` and receive
+it inside the callee with the `{children}` slot. Mirrors Go templ's
+children-prop convention.
+
+```ruitl
+component Card {
+    props {
+        title: String,
+    }
+}
+
+ruitl Card(title: String) {
+    <div class="card">
+        <h2>{title}</h2>
+        <div class="body">{children}</div>
+    </div>
+}
+
+ruitl Page() {
+    @Card(title: "Welcome".to_string()) {
+        <p>First paragraph.</p>
+        <p>Second paragraph.</p>
+    }
+}
+```
+
+Codegen auto-injects `pub children: Html` into the callee's Props struct
+whenever its template body references `{children}`. Call sites without a
+body block default the field to `Html::Empty`. Multiple `{children}` refs
+in the same template are allowed; each expands to a clone of the slot.
+The bare identifier `{children}` is the slot placeholder — `{my.children}`
+or any dotted path stays a normal expression.
+
 ## ⚙️ Build Process
 
 RUITL integrates seamlessly with Cargo's build system:

--- a/ruitl_compiler/src/codegen.rs
+++ b/ruitl_compiler/src/codegen.rs
@@ -236,7 +236,17 @@ impl CodeGenerator {
     fn generate_props_struct(&self, component: &ComponentDef) -> Result<TokenStream> {
         let props_name = format_ident!("{}Props", component.name);
 
-        if component.props.is_empty() {
+        // Does this component's template body reference `{children}`? If so,
+        // auto-emit a `pub children: Html` field on the Props struct — but
+        // only when the user hasn't already declared a `children` prop of
+        // their own. A user-declared `children` stays as-is (useful if they
+        // want a non-`Html` type or a different default), and the
+        // `{children}` slot simply reads whichever field is present.
+        let user_declared_children = component.props.iter().any(|p| p.name == "children");
+        let needs_children =
+            self.component_needs_children(&component.name) && !user_declared_children;
+
+        if component.props.is_empty() && !needs_children {
             return Ok(quote! {
                 pub type #props_name = EmptyProps;
             });
@@ -267,6 +277,12 @@ impl CodeGenerator {
                     // Non-optional field validation could go here
                 });
             }
+        }
+
+        if needs_children {
+            fields.push(quote! {
+                pub children: Html
+            });
         }
 
         let (struct_decl, impl_decl) = if component.generics.is_empty() {
@@ -451,8 +467,18 @@ impl CodeGenerator {
 
             TemplateAst::Match { expression, arms } => self.generate_match_code(expression, arms),
 
-            TemplateAst::Component { name, props } => {
-                self.generate_component_invocation_code(name, props)
+            TemplateAst::Component {
+                name,
+                props,
+                children,
+            } => self.generate_component_invocation_code(name, props, children.as_deref()),
+
+            TemplateAst::Children => {
+                // `{children}` — emit `props.children.clone()`. The owning
+                // component's Props struct is augmented with a
+                // `pub children: Html` field in `generate_props_struct` when
+                // the body contains this variant.
+                Ok(quote! { props.children.clone() })
             }
 
             TemplateAst::Fragment(nodes) => {
@@ -696,7 +722,8 @@ impl CodeGenerator {
             TemplateAst::Text(_)
             | TemplateAst::Expression(_)
             | TemplateAst::RawExpression(_)
-            | TemplateAst::Raw(_) => false,
+            | TemplateAst::Raw(_)
+            | TemplateAst::Children => false,
         }
     }
 
@@ -757,10 +784,21 @@ impl CodeGenerator {
                     Self::collect_idents_rec(&arm.body, out);
                 }
             }
-            TemplateAst::Component { props, .. } => {
+            TemplateAst::Component {
+                props, children, ..
+            } => {
                 for pv in props {
                     scan_idents(&pv.value, out);
                 }
+                if let Some(body) = children {
+                    Self::collect_idents_rec(body, out);
+                }
+            }
+            TemplateAst::Children => {
+                // The slot placeholder reads `props.children`; surface
+                // "children" so the prop-binding pass keeps that binding
+                // alive in the generated render body.
+                out.insert("children".to_string());
             }
             TemplateAst::Fragment(nodes) => {
                 for n in nodes {
@@ -872,6 +910,7 @@ impl CodeGenerator {
         &self,
         name: &str,
         props: &[PropValue],
+        children: Option<&TemplateAst>,
     ) -> Result<TokenStream> {
         let component_ident = format_ident!("{}", name);
         let props_ident = format_ident!("{}Props", name);
@@ -889,6 +928,22 @@ impl CodeGenerator {
             });
         }
 
+        // Feed the body block into the callee's auto-injected `children` prop.
+        // If the call site has a body, always emit `children: <rendered>`.
+        // If there is no body but the callee is defined locally and its
+        // template references `{children}`, emit `children: Html::Empty` so
+        // the generated struct literal is complete.
+        if let Some(body) = children {
+            let body_code = self.generate_ast_code(body)?;
+            prop_assignments.push(quote! {
+                children: #body_code
+            });
+        } else if self.component_needs_children(name) {
+            prop_assignments.push(quote! {
+                children: Html::Empty
+            });
+        }
+
         Ok(quote! {
             {
                 let component = #component_ident;
@@ -898,6 +953,55 @@ impl CodeGenerator {
                 component.render(&props, context)?
             }
         })
+    }
+
+    /// Does the named component's template body reference `{children}`? If
+    /// so, its generated Props struct carries a `pub children: Html` field
+    /// and every call site must populate it. Only inspects components defined
+    /// in the current file — out-of-file callees are on their own.
+    fn component_needs_children(&self, name: &str) -> bool {
+        self.file
+            .templates
+            .iter()
+            .find(|t| t.name == name)
+            .map(|t| Self::body_has_children_slot(&t.body))
+            .unwrap_or(false)
+    }
+
+    /// Recursively checks whether `ast` contains a `TemplateAst::Children`
+    /// node anywhere in its subtree. Used to decide whether a component's
+    /// Props struct needs the auto-injected `children: Html` field.
+    fn body_has_children_slot(ast: &TemplateAst) -> bool {
+        match ast {
+            TemplateAst::Children => true,
+            TemplateAst::Element { children, .. } => {
+                children.iter().any(Self::body_has_children_slot)
+            }
+            TemplateAst::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                Self::body_has_children_slot(then_branch)
+                    || else_branch
+                        .as_deref()
+                        .map(Self::body_has_children_slot)
+                        .unwrap_or(false)
+            }
+            TemplateAst::For { body, .. } => Self::body_has_children_slot(body),
+            TemplateAst::Match { arms, .. } => arms
+                .iter()
+                .any(|arm| Self::body_has_children_slot(&arm.body)),
+            TemplateAst::Fragment(nodes) => nodes.iter().any(Self::body_has_children_slot),
+            TemplateAst::Component { children, .. } => children
+                .as_deref()
+                .map(Self::body_has_children_slot)
+                .unwrap_or(false),
+            TemplateAst::Text(_)
+            | TemplateAst::Expression(_)
+            | TemplateAst::RawExpression(_)
+            | TemplateAst::Raw(_) => false,
+        }
     }
 }
 
@@ -1088,7 +1192,7 @@ mod tests {
         ];
 
         let result = generator
-            .generate_component_invocation_code("Button", &props)
+            .generate_component_invocation_code("Button", &props, None)
             .unwrap();
 
         let code = result.to_string();

--- a/ruitl_compiler/src/format.rs
+++ b/ruitl_compiler/src/format.rs
@@ -287,7 +287,11 @@ fn write_node(out: &mut String, ast: &TemplateAst, indent: usize) {
             pad(out, indent);
             out.push_str("}\n");
         }
-        TemplateAst::Component { name, props } => {
+        TemplateAst::Component {
+            name,
+            props,
+            children,
+        } => {
             pad(out, indent);
             out.push('@');
             out.push_str(name);
@@ -298,7 +302,19 @@ fn write_node(out: &mut String, ast: &TemplateAst, indent: usize) {
                 }
                 write_prop_value(out, p);
             }
-            out.push_str(")\n");
+            out.push(')');
+            if let Some(body) = children {
+                out.push_str(" {\n");
+                write_template_body(out, body, indent + 4);
+                pad(out, indent);
+                out.push_str("}\n");
+            } else {
+                out.push('\n');
+            }
+        }
+        TemplateAst::Children => {
+            pad(out, indent);
+            out.push_str("{children}\n");
         }
         TemplateAst::Fragment(_) => {
             write_template_body(out, ast, indent);
@@ -547,5 +563,24 @@ mod tests {
         let out = roundtrip(input);
         // Expect 3 levels of 4-space indentation on the innermost <p>.
         assert!(out.contains("            <p>Hi</p>"));
+    }
+
+    #[test]
+    fn formats_children_slot_and_bodied_invocation() {
+        let input = "component Card { props { title: String, } }\n\
+                     ruitl Card(title: String) { <div>{children}</div> }\n\
+                     component Page { props { msg: String, } }\n\
+                     ruitl Page(msg: String) { @Card(title: \"x\".to_string()) { <p>{msg}</p> } }";
+        let out = roundtrip(input);
+        assert!(
+            out.contains("{children}"),
+            "slot form must round-trip: {out}"
+        );
+        assert!(
+            out.contains("@Card(title: \"x\".to_string()) {"),
+            "bodied @-invocation must round-trip: {out}"
+        );
+        let twice = roundtrip(&out);
+        assert_eq!(out, twice, "formatter must be idempotent");
     }
 }

--- a/ruitl_compiler/src/parser.rs
+++ b/ruitl_compiler/src/parser.rs
@@ -98,8 +98,19 @@ pub enum TemplateAst {
         expression: String,
         arms: Vec<MatchArm>,
     },
-    /// Component invocation: @Button(props)
-    Component { name: String, props: Vec<PropValue> },
+    /// Component invocation: `@Button(props)` or `@Card(title: "x") { <p/>body }`.
+    /// `children` carries the optional `{ ... }` body block passed to the
+    /// callee as its `children: Html` prop.
+    Component {
+        name: String,
+        props: Vec<PropValue>,
+        children: Option<Box<TemplateAst>>,
+    },
+    /// `{children}` inside a template body — placeholder that is replaced at
+    /// codegen with `props.children.clone()`. The props struct for the owning
+    /// component auto-gains a `pub children: Html` field when this variant
+    /// appears anywhere in the body.
+    Children,
     /// Multiple nodes
     Fragment(Vec<TemplateAst>),
     /// Raw HTML (unescaped)
@@ -649,6 +660,13 @@ impl RuitlParser {
             return Err(self.error("Expected '}' to close expression"));
         }
 
+        // `{children}` (not `{children.foo}` or `{my.children}`) is the
+        // slot-placeholder form. Only recognise it when the bare identifier
+        // `children` appears with no further path/call syntax.
+        if !raw && expr.trim() == "children" {
+            return Ok(TemplateAst::Children);
+        }
+
         if raw {
             Ok(TemplateAst::RawExpression(expr))
         } else {
@@ -699,7 +717,25 @@ impl RuitlParser {
             return Err(self.error("Expected ')' to close component invocation"));
         }
 
-        Ok(TemplateAst::Component { name, props })
+        // Optional body block: `@Card(title: "x") { <p/>More }`. The body
+        // becomes the callee's `children` prop.
+        self.skip_whitespace();
+        let children = if self.check_char('{') {
+            self.advance(); // consume '{'
+            let body = self.parse_template_body()?;
+            if !self.match_char('}') {
+                return Err(self.error("Expected '}' to close component body"));
+            }
+            Some(Box::new(body))
+        } else {
+            None
+        };
+
+        Ok(TemplateAst::Component {
+            name,
+            props,
+            children,
+        })
     }
 
     fn parse_if_statement(&mut self) -> Result<TemplateAst> {
@@ -1516,9 +1552,15 @@ ruitl Greeting(name: String) {
         let mut parser = RuitlParser::new(input.to_string());
         let result = parser.parse_component_invocation().unwrap();
 
-        if let TemplateAst::Component { name, props } = result {
+        if let TemplateAst::Component {
+            name,
+            props,
+            children,
+        } = result
+        {
             assert_eq!(name, "Button");
             assert_eq!(props.len(), 2);
+            assert!(children.is_none(), "no body block → children is None");
 
             assert_eq!(props[0].name, "text");
             assert_eq!(props[0].value, "\"Click me\"");
@@ -1528,6 +1570,57 @@ ruitl Greeting(name: String) {
         } else {
             panic!("Expected component AST node");
         }
+    }
+
+    #[test]
+    fn test_parse_component_with_body() {
+        let input = r#"@Card(title: "Hi") { <p>Body</p> }"#;
+        let mut parser = RuitlParser::new(input.to_string());
+        let result = parser.parse_component_invocation().unwrap();
+
+        let TemplateAst::Component {
+            name,
+            props,
+            children,
+        } = result
+        else {
+            panic!("expected Component")
+        };
+        assert_eq!(name, "Card");
+        assert_eq!(props.len(), 1);
+        let body = children.expect("body block must be captured as children");
+        // The body should contain an element `<p>Body</p>`.
+        let children_vec = match *body {
+            TemplateAst::Fragment(v) => v,
+            other => vec![other],
+        };
+        let has_p = children_vec.iter().any(|n| matches!(n, TemplateAst::Element { tag, .. } if tag == "p"));
+        assert!(has_p, "body must contain <p> element");
+    }
+
+    #[test]
+    fn test_children_keyword_node() {
+        let input = "{children}";
+        let mut parser = RuitlParser::new(input.to_string());
+        let result = parser.parse_expression_node().unwrap();
+        assert!(
+            matches!(result, TemplateAst::Children),
+            "bare `{{children}}` must emit TemplateAst::Children, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_dotted_children_is_expression_not_slot() {
+        let input = "{my.children}";
+        let mut parser = RuitlParser::new(input.to_string());
+        let result = parser.parse_expression_node().unwrap();
+        // Dotted `children` is a regular field access — NOT the slot form.
+        assert!(
+            matches!(result, TemplateAst::Expression(ref s) if s == "my.children"),
+            "`{{my.children}}` must parse as Expression, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/tests/codegen_snapshots.rs
+++ b/tests/codegen_snapshots.rs
@@ -49,3 +49,4 @@ snap!(loops);
 snap!(match_arms);
 snap!(composition);
 snap!(generics);
+snap!(children);

--- a/tests/component_composition.rs
+++ b/tests/component_composition.rs
@@ -17,6 +17,8 @@
 use ruitl_compiler::{generate, parse_str, TemplateAst};
 
 const USER_LIST: &str = include_str!("fixtures/composition/UserList.ruitl");
+const CARD_WITH_CHILDREN: &str =
+    include_str!("fixtures/composition/CardWithChildren.ruitl");
 
 #[test]
 fn user_list_parses_with_composition_node() {
@@ -27,12 +29,21 @@ fn user_list_parses_with_composition_node() {
     let body = &file.templates[0].body;
     let composition = find_component_node(body)
         .expect("@UserCard composition node must exist somewhere in the body");
-    let TemplateAst::Component { name, props } = composition else {
+    let TemplateAst::Component {
+        name,
+        props,
+        children,
+    } = composition
+    else {
         unreachable!()
     };
     assert_eq!(name, "UserCard");
     let prop_names: Vec<&str> = props.iter().map(|p| p.name.as_str()).collect();
     assert_eq!(prop_names, vec!["name", "email", "role"]);
+    assert!(
+        children.is_none(),
+        "UserList invocation has no body block"
+    );
 }
 
 #[test]
@@ -59,6 +70,39 @@ fn user_list_codegen_emits_valid_invocation() {
     syn::parse_file(&code).unwrap_or_else(|e| {
         panic!("generated code is not valid Rust: {e}\n--- CODE ---\n{code}")
     });
+}
+
+#[test]
+fn card_with_children_codegen_auto_injects_children_field() {
+    let file = parse_str(CARD_WITH_CHILDREN).expect("CardWithChildren.ruitl must parse");
+    let code = generate(file).expect("codegen must succeed");
+
+    // The Card's Props struct should carry an auto-injected `children: Html` field.
+    let normalized: String = code.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        normalized.contains("pub children : Html")
+            || normalized.contains("pub children: Html"),
+        "CardWithChildrenProps must carry `pub children: Html`; got:\n{code}"
+    );
+
+    // The Shell's body-block invocation must feed a value into `children:` —
+    // codegen picks `Html::fragment(...)` for multi-child bodies and a direct
+    // `Html::Element(...)` for a single element. Accept both.
+    assert!(
+        code.contains("children : Html") || code.contains("children: Html"),
+        "Shell's @-call with body must populate the `children` field; got:\n{code}"
+    );
+
+    // The slot placeholder `{children}` should expand to a clone of props.children.
+    assert!(
+        code.contains("props . children . clone")
+            || code.contains("props.children.clone"),
+        "`{{children}}` slot must compile to props.children.clone(); got:\n{code}"
+    );
+
+    // Must be syntactically valid Rust.
+    syn::parse_file(&code)
+        .unwrap_or_else(|e| panic!("generated code is not valid Rust: {e}\n--- CODE ---\n{code}"));
 }
 
 fn find_component_node(node: &TemplateAst) -> Option<&TemplateAst> {

--- a/tests/fixtures/composition/CardWithChildren.ruitl
+++ b/tests/fixtures/composition/CardWithChildren.ruitl
@@ -1,0 +1,31 @@
+// End-to-end fixture for the `{children}` slot + `@X() { body }` syntax.
+//
+// CardWithChildren renders a wrapper <div> around its body block. The caller
+// (Shell) drops a `<p>` inside via `@CardWithChildren(...) { <p/> }`.
+
+component CardWithChildren {
+    props {
+        title: String,
+    }
+}
+
+ruitl CardWithChildren(title: String) {
+    <div class="card">
+        <h3>{title}</h3>
+        <div class="inner">{children}</div>
+    </div>
+}
+
+component Shell {
+    props {
+        msg: String,
+    }
+}
+
+ruitl Shell(msg: String) {
+    <main>
+        @CardWithChildren(title: "Hi".to_string()) {
+            <p>{msg}</p>
+        }
+    </main>
+}

--- a/tests/fixtures/snapshots/children.ruitl
+++ b/tests/fixtures/snapshots/children.ruitl
@@ -1,0 +1,39 @@
+// Exercises the `{children}` slot + `@Component() { body }` call syntax.
+//
+// Card has no user-declared props beyond `title` and references `{children}`
+// in its body; codegen must auto-inject `pub children: Html` into CardProps.
+// Outer passes a body block to Card, nests another bodied Card inside, and
+// also invokes Card without a body to verify the `children: Html::Empty`
+// fallback.
+
+component Card {
+    props {
+        title: String,
+    }
+}
+
+ruitl Card(title: String) {
+    <div class="card">
+        <h2>{title}</h2>
+        <div class="body">{children}</div>
+    </div>
+}
+
+component Outer {
+    props {
+        heading: String,
+    }
+}
+
+ruitl Outer(heading: String) {
+    <section>
+        <h1>{heading}</h1>
+        @Card(title: "Top".to_string()) {
+            <p>Top body</p>
+            @Card(title: "Nested".to_string()) {
+                <em>Nested body</em>
+            }
+        }
+        @Card(title: "Empty".to_string())
+    </section>
+}

--- a/tests/snapshots/codegen_snapshots__children.snap
+++ b/tests/snapshots/codegen_snapshots__children.snap
@@ -1,0 +1,98 @@
+---
+source: tests/codegen_snapshots.rs
+expression: out
+---
+use ruitl::prelude::*;
+use ruitl::html::*;
+#[derive(Debug, Clone)]
+pub struct CardProps {
+    pub title: String,
+    pub children: Html,
+}
+impl ComponentProps for CardProps {
+    fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+}
+#[derive(Debug)]
+pub struct Card;
+impl Component for Card {
+    type Props = CardProps;
+    #[allow(unused_variables)]
+    fn render(&self, props: &Self::Props, _context: &ComponentContext) -> Result<Html> {
+        let title = &props.title;
+        Ok(
+            Html::Element(
+                HtmlElement::new("div")
+                    .attr("class", "card")
+                    .child(
+                        Html::Element(
+                            HtmlElement::new("h2")
+                                .child(Html::text(&format!("{}", title))),
+                        ),
+                    )
+                    .child(
+                        Html::Element(
+                            HtmlElement::new("div")
+                                .attr("class", "body")
+                                .child(props.children.clone()),
+                        ),
+                    ),
+            ),
+        )
+    }
+}
+#[derive(Debug, Clone)]
+pub struct OuterProps {
+    pub heading: String,
+}
+impl ComponentProps for OuterProps {
+    fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+}
+#[derive(Debug)]
+pub struct Outer;
+impl Component for Outer {
+    type Props = OuterProps;
+    #[allow(unused_variables)]
+    fn render(&self, props: &Self::Props, context: &ComponentContext) -> Result<Html> {
+        let heading = &props.heading;
+        Ok(
+            Html::Element(
+                HtmlElement::new("section")
+                    .child(
+                        Html::Element(
+                            HtmlElement::new("h1")
+                                .child(Html::text(&format!("{}", heading))),
+                        ),
+                    )
+                    .child({
+                        let component = Card;
+                        let props = CardProps {
+                            title: "Top".to_string(),
+                            children: Html::fragment(
+                                vec![
+                                    Html::Element(HtmlElement::new("p")
+                                    .child(Html::text("Top body"))), { let component = Card; let
+                                    props = CardProps { title : "Nested".to_string(), children :
+                                    Html::Element(HtmlElement::new("em")
+                                    .child(Html::text("Nested body"))) }; component.render(&
+                                    props, context) ? }
+                                ],
+                            ),
+                        };
+                        component.render(&props, context)?
+                    })
+                    .child({
+                        let component = Card;
+                        let props = CardProps {
+                            title: "Empty".to_string(),
+                            children: Html::Empty,
+                        };
+                        component.render(&props, context)?
+                    }),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
…te inheritance

Add Go templ-style children-prop: `@Card(title: "x") { <body/> }` passes the body block into the callee's auto-injected `children: Html` prop, read via the bare `{children}` slot placeholder.

- parser: new TemplateAst::Children variant; TemplateAst::Component gains optional `children: Box<TemplateAst>`. `{children}` (bare, no dots) emits Children node; `{my.children}` stays an Expression.
- codegen: auto-injects `pub children: Html` into {Name}Props when the template body references the slot; skipped if the user already declared a `children` prop (user declaration wins, avoiding duplicate fields). Call sites with a body feed `children: <rendered>`; call sites without a body on a callee with the slot get `children: Html::Empty`.
- format: round-trips `{children}` and `@X(props) { body }` idempotently.
- tests: snapshot fixture + composition integration test assert field injection, slot expansion, and valid Rust output.