### PR TITLE
fix(build+docs): docs.rs-ready + version sync, bump to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 
 [package]
 name = "ruitl"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Template compiler for type-safe, server-rendered HTML components in Rust"
 license = "MIT OR Apache-2.0"
@@ -85,13 +85,13 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 
 # Compiler (parser + codegen) — shared with build.rs.
 # Path + version: path wins for workspace dev, version is what crates.io uses.
-ruitl_compiler = { path = "ruitl_compiler", version = "0.2.1" }
+ruitl_compiler = { path = "ruitl_compiler", version = "0.2.2" }
 
 # Development dependencies
 # Build dependencies
 [build-dependencies]
 walkdir = "2.3"
-ruitl_compiler = { path = "ruitl_compiler", version = "0.2.1" }
+ruitl_compiler = { path = "ruitl_compiler", version = "0.2.2" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# RUITL - Rust UI Template Language v0.2.1
+# RUITL - Rust UI Template Language v0.2.2
 
 [![Crates.io](https://img.shields.io/crates/v/ruitl.svg)](https://crates.io/crates/ruitl)
 [![Documentation](https://docs.rs/ruitl/badge.svg)](https://docs.rs/ruitl)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
 
-> **Status: Pre-release (v0.2.1)** — Core feature set stable. Breaking changes possible before v1.0 while SSG and ergonomics settle.
+> **Status: Pre-release (v0.2.2)** — Core feature set stable. Breaking changes possible before v1.0 while SSG and ergonomics settle.
 
 A template compiler for building type-safe HTML components in Rust, modelled on Go's [templ](https://templ.guide). RUITL compiles `.ruitl` template files into sibling `*_ruitl.rs` files (committed to source control, reviewable in diffs) and links them into your binary at build time.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# RUITL - Rust UI Template Language v0.2.0
+# RUITL - Rust UI Template Language v0.2.1
 
 [![Crates.io](https://img.shields.io/crates/v/ruitl.svg)](https://crates.io/crates/ruitl)
 [![Documentation](https://docs.rs/ruitl/badge.svg)](https://docs.rs/ruitl)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
 
-> **Status: Pre-release (v0.2.0)** — Core feature set stable. Breaking changes possible before v1.0 while SSG and ergonomics settle.
+> **Status: Pre-release (v0.2.1)** — Core feature set stable. Breaking changes possible before v1.0 while SSG and ergonomics settle.
 
 A template compiler for building type-safe HTML components in Rust, modelled on Go's [templ](https://templ.guide). RUITL compiles `.ruitl` template files into sibling `*_ruitl.rs` files (committed to source control, reviewable in diffs) and links them into your binary at build time.
 
@@ -107,7 +107,7 @@ This creates a complete project structure with example components, HTTP server, 
 ```toml
 # Cargo.toml
 [dependencies]
-ruitl = "0.1.0"
+ruitl = "0.2"
 tokio = { version = "1.0", features = ["full"] }
 
 [build-dependencies]

--- a/TEMPLATE_COMPILATION.md
+++ b/TEMPLATE_COMPILATION.md
@@ -26,7 +26,7 @@ Add RUITL to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruitl = "0.1.0"
+ruitl = "0.2"
 tokio = { version = "1.0", features = ["full"] }
 
 [build-dependencies]

--- a/ruitl_compiler/Cargo.toml
+++ b/ruitl_compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruitl_compiler"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Parser and code generator for the RUITL (Rust UI Template Language)"
 license = "MIT OR Apache-2.0"

--- a/ruitl_lsp/Cargo.toml
+++ b/ruitl_lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruitl_lsp"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Language server for RUITL templates — diagnostics, formatting, completion, hover, go-to-definition"
 license = "MIT OR Apache-2.0"
@@ -26,7 +26,7 @@ path = "src/lib.rs"
 tower-lsp = "0.20"
 tokio = { version = "1.0", features = ["rt-multi-thread", "io-std", "io-util", "macros", "sync"] }
 dashmap = "5.5"
-ruitl_compiler = { path = "../ruitl_compiler", version = "0.2.1" }
+ruitl_compiler = { path = "../ruitl_compiler", version = "0.2.2" }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt-multi-thread", "io-std", "io-util", "macros", "sync", "test-util"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -964,7 +964,7 @@ path = "bin/ruitl.rs"
 
 [dependencies]
 # RUITL dependency - Update this based on your setup:
-# For published version: ruitl = "0.1.0"
+# For published version: ruitl = "0.2"
 # For git version: ruitl = {{ git = "https://github.com/sirhco/ruitl.git" }}
 # For local development: ruitl = {{ path = "../path/to/ruitl" }}
 ruitl = {{ git = "https://github.com/sirhco/ruitl.git" }}
@@ -999,7 +999,7 @@ path = "bin/ruitl.rs"
 
 [dependencies]
 # RUITL dependency - Update this based on your setup:
-# For published version: ruitl = "0.1.0"
+# For published version: ruitl = "0.2"
 # For git version: ruitl = {{ git = "https://github.com/sirhco/ruitl.git" }}
 # For local development: ruitl = {{ path = "../path/to/ruitl" }}
 ruitl = {{ git = "https://github.com/sirhco/ruitl.git" }}


### PR DESCRIPTION
## Summary

0.2.1 shipped but docs.rs failed to build it and README/scaffolder still
referenced mixed versions. This PR fixes both and bumps the workspace to
0.2.2 so the corrected metadata actually reaches users (0.2.1 is frozen
on crates.io).

## Fixes in this PR

### docs.rs build

- `build.rs` now short-circuits when `DOCS_RS=1` (set by docs.rs) or
  `RUITL_SKIP_BUILD=1`. docs.rs mounts the crate source read-only, and
  the committed sibling `*_ruitl.rs` files already match what we'd emit.
- `[package.metadata.docs.rs]` on `ruitl` switches from `all-features = true`
  to an explicit `features = [\"server\", \"static\", \"dev\", \"testing\"]`.
  Drops the optional `minify` feature, whose transitive
  `minify-html-common` build script fetches `www.unpkg.com` — blocked by
  docs.rs's no-network sandbox.

### Publish metadata

- `LICENSE-MIT` + `LICENSE-APACHE` committed at repo root (Cargo.toml
  declares dual license).
- `ruitl_compiler` dep now pinned by version in both `ruitl` and
  `ruitl_lsp` (regular + build-dependencies). crates.io rejects
  path-only inter-crate deps.
- `ruitl_compiler/README.md` added; `readme` field now points at it so
  the crates.io page renders real content.
- `ruitl_compiler`, `ruitl_lsp`, `ruitl` all gained `documentation`,
  `keywords`, `categories`, `readme`, and
  `[package.metadata.docs.rs]` metadata blocks.

### Version sync

- All three crates bumped 0.2.1 → 0.2.2.
- README title + status line: `v0.2.1` → `v0.2.2`.
- README + TEMPLATE_COMPILATION.md install snippets: `ruitl = \"0.1.0\"`
  → `ruitl = \"0.2\"` (caret form matches 0.2.x patches without more
  doc churn).
- Scaffolder comments in `src/cli.rs` that suggested a published
  version: `ruitl = \"0.1.0\"` → `ruitl = \"0.2\"`. The scaffolded
  project's own `version = \"0.1.0\"` stays — correct default for a
  brand-new user project.

## Test plan

- [ ] `cargo build` — clean (warning about compiled templates expected).
- [ ] `DOCS_RS=1 cargo build -p ruitl --no-default-features --features \"server static dev testing\"` —
  clean, no build.rs warning (short-circuit works).
- [ ] `cargo test --lib` — 39 pass.
- [ ] After merge: republish in order:
  ```
  cargo publish -p ruitl_compiler
  cargo publish -p ruitl
  cargo publish -p ruitl_lsp
  ```
- [ ] Watch docs.rs queue at https://docs.rs/crate/ruitl/0.2.2/builds —
  expect green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)